### PR TITLE
Improve definition of lock types in open-trans query.

### DIFF
--- a/utilities/open_transactions_geq_DBv71.sql
+++ b/utilities/open_transactions_geq_DBv71.sql
@@ -43,7 +43,7 @@ with
 							S.SESSION_ID,
 							case
 								when
-									(S.STATUS not in ('IDLE', 'DISCONNECTED')) OR
+									(S.STATUS not in ('IDLE', 'DISCONNECTED', 'QUEUED')) OR
 									(
 										S.COMMAND_NAME not in ('COMMIT', 'ROLLBACK', 'NOT SPECIFIED')
 									)
@@ -51,7 +51,13 @@ with
 									case
 										when
 											S.COMMAND_NAME in (
-												'SELECT', 'DESCRIBE', 'OPEN SCHEMA', 'CLOSE SCHEMA', 'FLUSH STATISTICS', 'EXECUTE SCRIPT'
+												'SELECT',
+												'DESCRIBE',
+												'OPEN SCHEMA',
+												'CLOSE SCHEMA',
+												'FLUSH STATISTICS',
+												'EXECUTE SCRIPT',
+												'EXPORT'
 											)
 										then
 											1
@@ -88,7 +94,8 @@ with
 																	'OPEN SCHEMA',
 																	'CLOSE SCHEMA',
 																	'FLUSH STATISTICS',
-																	'EXECUTE SCRIPT'
+																	'EXECUTE SCRIPT',
+																	'EXPORT'
 																)
 															then
 																1


### PR DESCRIPTION
After reviewing the results of the query on a system that is hit by active session limit it was noted that definition of possible locks being hold could be improved.